### PR TITLE
fix: set timeout for events query (timetable)

### DIFF
--- a/shared/src/components/timetable/feedEvents/index.tsx
+++ b/shared/src/components/timetable/feedEvents/index.tsx
@@ -50,6 +50,7 @@ const FeedEvents = (
       gcTime: 10 * 60 * 1000,
       staleTime: 5 * 60 * 1000,
       initialPageParam: 0,
+      retry: false,
       getNextPageParam: (lastPage, _, lastPageParam) => {
         if (lastPage.length < EVENTS_LIMIT) {
           return undefined;

--- a/shared/src/network/httpClient/psuToolsClient.ts
+++ b/shared/src/network/httpClient/psuToolsClient.ts
@@ -33,11 +33,13 @@ const client = {
       pageNumber = 0,
       pageSize,
       filters,
+      timeout = 3000,
     }: {
       dateFrom: Date;
       pageNumber: number;
       pageSize: number;
       filters?: number[] | null;
+      timeout?: number;
     }) => {
       const response = await axios.get<Event[]>(
         `${api.psuTools}/events-api/events?pageNumber=${pageNumber}&pageSize=${pageSize}&showPastEvents=false&datetimeFrom=${
@@ -45,6 +47,7 @@ const client = {
             .toISOString()
             .split('.')[0]
         }${filters && filters.length ? `&tagId=${JSON.stringify(filters).slice(1, -1).trim()}` : ''}`,
+        timeout ? { signal: AbortSignal.timeout(timeout) } : undefined,
       );
       return response.data;
     },


### PR DESCRIPTION
 Ставит стандартный timeout для запроса событий в 3000 мс. Отключает retry